### PR TITLE
Make the steps from the README file work

### DIFF
--- a/build_tools/buildfmt.sh
+++ b/build_tools/buildfmt.sh
@@ -1,3 +1,9 @@
 #!/bin/bash -e
 
-exec "$RUNFILES/../dbx_build_tools/go/src/github.com/bazelbuild/buildtools/buildifier/buildifier" -add_tables "$RUNFILES/../dbx_build_tools/build_tools/buildifier.json" "$@"
+if [ -d $RUNFILES/../dbx_build_tools ]; then
+  dbx_build_tools_root=$RUNFILES/../dbx_build_tools
+else
+  dbx_build_tools_root=$RUNFILES/external/dbx_build_tools
+fi
+
+exec "$dbx_build_tools_root/go/src/github.com/bazelbuild/buildtools/buildifier/buildifier" -add_tables "$dbx_build_tools_root/build_tools/buildifier.json" "$@"

--- a/build_tools/bzl_lib/itest/bzl-itest-init.sh
+++ b/build_tools/bzl_lib/itest/bzl-itest-init.sh
@@ -5,7 +5,14 @@
 
 # we do not want to exit on first failure here.
 set +e
-source $RUNFILES/../dbx_build_tools/build_tools/bzl_lib/itest/bzl-itest-common.sh
+
+if [ -d $RUNFILES/../dbx_build_tools ]; then
+  dbx_build_tools_root=$RUNFILES/../dbx_build_tools
+else
+  dbx_build_tools_root=$RUNFILES/external/dbx_build_tools
+fi
+
+source $dbx_build_tools_root/build_tools/bzl_lib/itest/bzl-itest-common.sh
 
 if [ -d "$CLEANDIR" ]; then
   find $CLEANDIR -mindepth 1 -delete

--- a/build_tools/bzl_lib/itest/bzl-itest-wait.sh
+++ b/build_tools/bzl_lib/itest/bzl-itest-wait.sh
@@ -2,7 +2,13 @@
 
 # this script is used by `bzl itest-run` to wait for services to come up.
 
-source $RUNFILES/../dbx_build_tools/build_tools/bzl_lib/itest/bzl-itest-common.sh
+if [ -d $RUNFILES/../dbx_build_tools ]; then
+  dbx_build_tools_root=$RUNFILES/../dbx_build_tools
+else
+  dbx_build_tools_root=$RUNFILES/external/dbx_build_tools
+fi
+
+source $dbx_build_tools_root/build_tools/bzl_lib/itest/bzl-itest-common.sh
 
 # wait for pid file to exist
 while [ ! -e $PID_FILE_LOCATION ]; do

--- a/build_tools/go/go_test_wrapper.sh
+++ b/build_tools/go/go_test_wrapper.sh
@@ -5,6 +5,12 @@ shift
 test_exec="$1"
 shift
 
+if [ -d $RUNFILES/../dbx_build_tools ]; then
+  dbx_build_tools_root=$RUNFILES/../dbx_build_tools
+else
+  dbx_build_tools_root=$RUNFILES/external/dbx_build_tools
+fi
+
 if [[ -n "$COVERAGE_OUTPUT_FILE" ]]; then
     coverage_out=$(mktemp)
 else
@@ -20,10 +26,10 @@ set +e
 retcode=${PIPESTATUS[0]}
 set -e
 
-"$RUNFILES/../dbx_build_tools/../go_1_12_16_linux_amd64_tar_gz/go/pkg/tool/linux_amd64/test2json" < "$temp" -t | "$RUNFILES/../dbx_build_tools/go/src/dropbox/build_tools/gojunit/gojunit/gojunit" -target "$target"
+"$dbx_build_tools_root/../go_1_12_16_linux_amd64_tar_gz/go/pkg/tool/linux_amd64/test2json" < "$temp" -t | "$dbx_build_tools_root/go/src/dropbox/build_tools/gojunit/gojunit/gojunit" -target "$target"
 
 if [[ -n "$COVERAGE_OUTPUT_FILE" ]]; then
-    "$RUNFILES/../dbx_build_tools/go/src/dropbox/build_tools/gocov2cobertura/gocov2cobertura" < "$coverage_out" > "$COVERAGE_OUTPUT_FILE"
+    "$dbx_build_tools_root/go/src/dropbox/build_tools/gocov2cobertura/gocov2cobertura" < "$coverage_out" > "$COVERAGE_OUTPUT_FILE"
 fi
 
 exit "$retcode"

--- a/build_tools/services/restart_test.sh
+++ b/build_tools/services/restart_test.sh
@@ -1,10 +1,16 @@
 #!/bin/bash -eux
 
+if [ -d $RUNFILES/../dbx_build_tools ]; then
+  dbx_build_tools_root=$RUNFILES/../dbx_build_tools
+else
+  dbx_build_tools_root=$RUNFILES/external/dbx_build_tools
+fi
+
 # Use a var to avoid a pipe - that would make number of processes nondeterministic
 out=$(ps ux)
 procs1=$(wc -l <<< out)
-$RUNFILES/../dbx_build_tools/go/src/dropbox/build_tools/svcctl/cmd/svcctl/svcctl stop-all
-$RUNFILES/../dbx_build_tools/go/src/dropbox/build_tools/svcctl/cmd/svcctl/svcctl start-all
+$dbx_build_tools_root/go/src/dropbox/build_tools/svcctl/cmd/svcctl/svcctl stop-all
+$dbx_build_tools_root/go/src/dropbox/build_tools/svcctl/cmd/svcctl/svcctl start-all
 out=$(ps ux)
 procs2=$(wc -l <<< out)
 if [ "$procs1" -lt "$procs2" ]; then


### PR DESCRIPTION
When used as an external dependency dbx_build_tools and its tools
are unpacked in an "external" subdirectory. Following the steps in
the README file, adding dbx_build_tools as an http_archive, it is
unpacked in this way. This causes the itest-* tooling and others
to not work as the scripts are looking in the wrong place for
their runfiles.

Since dbx_build_tools is not always used as an external dependency,
some logic to figure out where the runfiles directory can be found
is required.