### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ drte_deps()
 
 register_toolchains(
     "@dbx_build_tools//thirdparty/cpython:drte-off-27-toolchain",
-    "@dbx_build_tools//thirdparty/cpython:drte-off-37-toolchain",
     "@dbx_build_tools//thirdparty/cpython:drte-off-38-toolchain",
 )
 ```


### PR DESCRIPTION
Remove reference to python 3.7 which no longer exists in repository.