### PR TITLE
Update bazelify.sh

### DIFF
--- a/thirdparty/openssl/bazelify.sh
+++ b/thirdparty/openssl/bazelify.sh
@@ -25,7 +25,7 @@ echo -e "OPENSSLCONF_H = \"\"\"$(grep ^# include/openssl/opensslconf.h)\"\"\"\n"
 echo -e "BN_CONF_H = \"\"\"$(grep ^# include/crypto/bn_conf.h)\"\"\"\n" >> "$mydir/BUILD.openssl"
 echo -e "DSO_CONF_H = \"\"\"$(grep ^# include/crypto/dso_conf.h)\"\"\"\n" >> "$mydir/BUILD.openssl"
 echo -e "APPS_PROGS_H = \"\"\"$(< apps/progs.h)\"\"\"\n" >> "$mydir/BUILD.openssl"
-perl -l -Mconfigdata "$mydir/extract_srcs.pl" >> "$mydir/BUILD.openssl"
+perl -I. -l -Mconfigdata "$mydir/extract_srcs.pl" >> "$mydir/BUILD.openssl"
 echo "# END GENERATED CODE\n" >> "$mydir/BUILD.openssl"
 cat "$mydir/BUILD.openssl.tail" >> "$mydir/BUILD.openssl"
 popd


### PR DESCRIPTION
Explicitly add the current working directory for include path for call to perl.

Needed this for perl 5.26.1 on aarch64 for bazelify.sh script to complete.