### PR TITLE
Remove use of deprecated `compiler_executable` and `ar_executable`.

### DIFF
--- a/build_tools/py/py.bzl
+++ b/build_tools/py/py.bzl
@@ -75,6 +75,7 @@ def _add_vpip_compiler_args(ctx, cc_toolchain, copts, conly, args):
     archiver = cc_common.get_tool_for_action(feature_configuration = feature_configuration, action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME)
     args.add(c_compiler, format = "--compiler-executable=%s")
     args.add(archiver, format = "--archiver=%s")
+    args.add("--extra-path=" + '/'.join(c_compiler.split('/')[:-1]))
 
     # Add base compiler flags from the crosstool. These contain the correct
     # include paths and other side-wide settings like -fstack-protector. These

--- a/build_tools/py/py.bzl
+++ b/build_tools/py/py.bzl
@@ -2,6 +2,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "CPP_COMPILE_ACTION_NAME",
+    "CPP_LINK_STATIC_LIBRARY_ACTION_NAME",
     "CPP_LINK_DYNAMIC_LIBRARY_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
 )
@@ -69,9 +70,11 @@ ROOT_PLACEHOLDER = "____root____"
 
 def _add_vpip_compiler_args(ctx, cc_toolchain, copts, conly, args):
     # Set the compiler to the crosstool compilation driver.
-    args.add(cc_toolchain.compiler_executable, format = "--compiler-executable=%s")
-    args.add(cc_toolchain.ar_executable, format = "--archiver=%s")
     feature_configuration = cc_common.configure_features(ctx = ctx, cc_toolchain = cc_toolchain)
+    c_compiler = cc_common.get_tool_for_action(feature_configuration = feature_configuration, action_name = C_COMPILE_ACTION_NAME if conly else CPP_COMPILE_ACTION_NAME)
+    archiver = cc_common.get_tool_for_action(feature_configuration = feature_configuration, action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME)
+    args.add(c_compiler, format = "--compiler-executable=%s")
+    args.add(archiver, format = "--archiver=%s")
 
     # Add base compiler flags from the crosstool. These contain the correct
     # include paths and other side-wide settings like -fstack-protector. These


### PR DESCRIPTION
These values assume that the compiler and ar exist in the path of the toolchain definition
and so for some toolchains incorrectly guess the location of ar / gcc.

Update the configuration to use the `cc_common.get_tool_for_action` API which
returns the tool configured by the toolchain.