### PR TITLE
Turn off inculsion of immintrin.h

### DIFF
--- a/thirdparty/xz/BUILD.xz
+++ b/thirdparty/xz/BUILD.xz
@@ -209,7 +209,6 @@ cat <<'END_OF_FILE' > $@
 #define HAVE_FUTIMENS 1
 #define HAVE_GETOPT_H 1
 #define HAVE_GETOPT_LONG 1
-#define HAVE_IMMINTRIN_H 1
 #define HAVE_INTTYPES_H 1
 #define HAVE_LIMITS_H 1
 #define HAVE_MBRTOWC 1


### PR DESCRIPTION
This is the only change required to get xz to compile on aarch64; it doesn't appear that intrinsics are used in the x86_64 code path so I don't think there is any impact in turning off this option?