### PR TITLE
Replace - with _ in default provides name for python packages

### DIFF
--- a/build_tools/py/py.bzl
+++ b/build_tools/py/py.bzl
@@ -823,7 +823,7 @@ def dbx_py_pypi_piplib(
     if provides == None:
         # If no explicit 'provides' attribute is specified, default to using the target name itself.
         if hidden_provides == None:
-            provides = [name]
+            provides = [name.replace("-", "_")]
         else:
             provides = []
 
@@ -857,7 +857,7 @@ def dbx_py_local_piplib(
     if provides == None:
         # If no explicit 'provides' attribute is specified, default to using the target name itself.
         if hidden_provides == None:
-            provides = [name]
+            provides = [name.replace("-", "_")]
         else:
             provides = []
 


### PR DESCRIPTION
It is a common convention to name the pypi package with - and have the python package name be the same but with _ replacing - so update the default for provides to take this into account.