### PR TITLE
Disable thin_lto when calculating build flags

### DIFF
--- a/build_tools/go/go.bzl
+++ b/build_tools/go/go.bzl
@@ -256,7 +256,7 @@ def go_binary_impl(ctx):
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features + features,
-        unsupported_features = ctx.disabled_features,
+        unsupported_features = ctx.disabled_features + ["thin_lto"],
     )
     link_variables = cc_common.create_link_variables(
         feature_configuration = feature_configuration,
@@ -482,7 +482,7 @@ def _compute_cgo_parameters(ctx, native_info):
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
+        unsupported_features = ctx.disabled_features + ["thin_lto"],
     )
     compiler_inputs_direct = []
     compiler_inputs_trans = [

--- a/build_tools/py/mypy.bzl
+++ b/build_tools/py/mypy.bzl
@@ -335,7 +335,7 @@ def _build_mypyc_ext_module(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
+        unsupported_features = ctx.disabled_features + ["thin_lto"],
     )
 
     so_name = "%s.cpython-38-x86_64-linux-gnu.so" % group_name

--- a/build_tools/py/py.bzl
+++ b/build_tools/py/py.bzl
@@ -74,7 +74,7 @@ def _add_vpip_compiler_args(ctx, cc_toolchain, copts, conly, args):
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
+        unsupported_features = ctx.disabled_features + ["thin_lto"],
     )
     c_compiler = cc_common.get_tool_for_action(
         feature_configuration = feature_configuration,


### PR DESCRIPTION
Bazel's `thin_lto` flags assume that the compilation is occurring in multiple steps including an indexing step. This assumption is not valid for compilation within go or python and so remove the `thin_lto` feature from the list of supported features when calculating flags.