### PR TITLE
Set PYTHONPATH env variable so that is propagates to child invocations of python

### DIFF
--- a/build_tools/py/common.bzl
+++ b/build_tools/py/common.bzl
@@ -111,6 +111,7 @@ except Exception:
 script_dir = os.path.join(runfiles, {main_package})
 filepath = os.path.join(script_dir, {main})
 sys.argv[0] = filepath
+os.environ["PYTHONPATH"] = ":".join(sys.path)
 
 import types
 module = types.ModuleType('__main__')


### PR DESCRIPTION
We found that if you have python packages such as jupyter that spawn child process of python then they expect to pick up the same PYTHONPATH as the parent process so setting PYTHONPATH in the wrapper resolves this issue.