### PR TITLE
If RUNFILES_DIR is set externally use that for finding runfiles path

### DIFF
--- a/build_tools/bazel/runfiles.tmpl
+++ b/build_tools/bazel/runfiles.tmpl
@@ -1,4 +1,8 @@
 #!/bin/bash -eu
+
+if [ ! -x ${RUNFILES_DIR:+x} ]; then
+    runfiles=${RUNFILES_DIR}
+else
 abs_binary="$0"
 if [[ ! "$abs_binary" == /* ]]; then
     abs_binary=$(pwd)/"$abs_binary"
@@ -20,6 +24,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     runfiles="$(python -c "import os;print(os.path.realpath('$abs_binary.runfiles'))")"
 else
     runfiles="$(/bin/readlink -f "$abs_binary".runfiles)"
+fi
 fi
 
 export RUNFILES="$runfiles"/{workspace_name}


### PR DESCRIPTION
If a `dbx_py_binary` is set as a data member of e.g. a `sh_binary` and called from that script then it fails to correctly find the runfile directory.
This change picks up any existing `RUNFILES_DIR` set by a parent script e.g. via bash runfiles so that the correct runfiles directory is found.