### PR TITLE
Fix python3 stdlib-zip

### DIFF
--- a/thirdparty/cpython/BUILD.python38
+++ b/thirdparty/cpython/BUILD.python38
@@ -1123,6 +1123,7 @@ genrule(
     outs = ["lib/python38.zip"],
     cmd = """
 export ASAN_OPTIONS=detect_leaks=0
+export PYTHONHASHSEED=0
 mkdir $(@D)/python3.8
 touch $(@D)/python3.8/os.py
 mkdir $(@D)/python3.8/lib-dynload

--- a/thirdparty/cpython/BUILD.python39
+++ b/thirdparty/cpython/BUILD.python39
@@ -1163,6 +1163,7 @@ genrule(
     outs = ["lib/python39.zip"],
     cmd = """
 export ASAN_OPTIONS=detect_leaks=0
+export PYTHONHASHSEED=0
 mkdir $(@D)/python3.9
 touch $(@D)/python3.9/os.py
 mkdir $(@D)/python3.9/lib-dynload


### PR DESCRIPTION
The current implementation of `@org_python_cpython_38//:stdlib-zip` produces different python byte-code on each compilation. As you can imagine, this also means that each rebuild results in a different hash so all tests are invalidated. I initially tracked this down because it's one of the only actions with different outputs and the same inputs in my build. You can reproduce this by building it twice and inspecting the python byte-code with [diffoscope](https://diffoscope.org):

```bash
# Build 2 copies
bazel build @org_python_cpython_38//:stdlib-zip
cp bazel-bin/external/org_python_cpython_38/lib/python38.zip .
bazel clean 
bazel build @org_python_cpython_38//:stdlib-zip
# Inspect with diffoscope
diffoscope bazel-bin/external/org_python_cpython_38/lib/python38.zip  python38.zip
```

I believe this is due to the ordering of sets in the compiled byte-code, but I am not certain. Either way, defining a set `PYTHONHASHSEED` fixes the issue (and can be verified using the same steps above). 