### PR TITLE
Use dbx_py_binary for running vpip

### DIFF
--- a/build_tools/py/BUILD
+++ b/build_tools/py/BUILD
@@ -3,7 +3,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//build_tools/py:py.bzl", "dbx_internal_bootstrap_py_binary")
+load("//build_tools/py:py.bzl", "dbx_internal_bootstrap_py_binary", "dbx_py_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 py_binary(
@@ -16,9 +16,10 @@ sh_binary(
     srcs = ["ldshared-wrapper.sh"],
 )
 
-py_binary(
+dbx_py_binary(
     name = "vpip",
     srcs = ["vpip.py"],
+    main = "vpip.py",
     data = [
         ":ldshared-wrapper",
         ":sanitizer-extra-runfiles",
@@ -31,7 +32,6 @@ py_binary(
         # testing of an unreleased build.
         # "@com_git_scm_git//:executables",
     ],
-    python_version = "PY3",
 )
 
 py_binary(


### PR DESCRIPTION
This ensures that the dependencies installed via vpip are using the correct version of python as the version of python configured in the rules_python toolchain may be different to that used by the dbx_py_binary rules.