### PR TITLE
Update squashfs-tools to 4.5.1

### DIFF
--- a/build_tools/bazel/external_workspace.bzl
+++ b/build_tools/bazel/external_workspace.bzl
@@ -8,7 +8,7 @@ def filename_from_label(label):
 DEFAULT_EXTERNAL_URLS = {
     "abseil_py": ["https://github.com/abseil/abseil-py/archive/pypi-v0.7.1.tar.gz"],
     "bazel_skylib": ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz"],
-    "com_github_plougher_squashfs_tools": ["https://github.com/plougher/squashfs-tools/archive/4.4.tar.gz"],
+    "com_github_plougher_squashfs_tools": ["https://github.com/plougher/squashfs-tools/archive/4.5.1.tar.gz"],
     "cpython_39": ["https://www.python.org/ftp/python/3.9.11/Python-3.9.11.tar.xz"],
     "go_1_16_linux_amd64_tar_gz": ["https://dl.google.com/go/go1.16.7.linux-amd64.tar.gz"],
     "go_1_18_linux_amd64_tar_gz": ["https://dl.google.com/go/go1.18.linux-amd64.tar.gz"],
@@ -65,9 +65,9 @@ def drte_deps(urls = DEFAULT_EXTERNAL_URLS):
     http_archive(
         name = "com_github_plougher_squashfs_tools",
         urls = urls["com_github_plougher_squashfs_tools"],
-        sha256 = "a7fa4845e9908523c38d4acf92f8a41fdfcd19def41bd5090d7ad767a6dc75c3",
+        sha256 = "277b6e7f75a4a57f72191295ae62766a10d627a4f5e5f19eadfbc861378deea7",
         build_file = filename_from_label("@dbx_build_tools//thirdparty/squashfs-tools:BUILD.squashfs-tools"),
-        strip_prefix = "squashfs-tools-4.4",
+        strip_prefix = "squashfs-tools-4.5.1",
     )
 
     http_archive(

--- a/thirdparty/squashfs-tools/BUILD.squashfs-tools
+++ b/thirdparty/squashfs-tools/BUILD.squashfs-tools
@@ -7,6 +7,7 @@ cc_binary(
         "squashfs-tools/caches-queues-lists.h",
         "squashfs-tools/compressor.c",
         "squashfs-tools/compressor.h",
+        "squashfs-tools/endian_compat.h",
         "squashfs-tools/error.h",
         "squashfs-tools/fnmatch_compat.h",
         "squashfs-tools/gzip_wrapper.c",
@@ -17,16 +18,17 @@ cc_binary(
         "squashfs-tools/lz4_wrapper.h",
         "squashfs-tools/mksquashfs.c",
         "squashfs-tools/mksquashfs.h",
+        "squashfs-tools/mksquashfs_error.h",
         "squashfs-tools/process_fragments.c",
         "squashfs-tools/process_fragments.h",
         "squashfs-tools/progressbar.c",
         "squashfs-tools/progressbar.h",
         "squashfs-tools/pseudo.c",
         "squashfs-tools/pseudo.h",
-        "squashfs-tools/read_file.c",
         "squashfs-tools/read_fs.c",
         "squashfs-tools/read_fs.h",
         "squashfs-tools/read_xattrs.c",
+        "squashfs-tools/reader.c",
         "squashfs-tools/restore.c",
         "squashfs-tools/restore.h",
         "squashfs-tools/sort.c",
@@ -34,6 +36,9 @@ cc_binary(
         "squashfs-tools/squashfs_fs.h",
         "squashfs-tools/squashfs_swap.h",
         "squashfs-tools/swap.c",
+        "squashfs-tools/tar.c",
+        "squashfs-tools/tar.h",
+        "squashfs-tools/tar_xattr.c",
         "squashfs-tools/xattr.c",
         "squashfs-tools/xattr.h",
         "squashfs-tools/zstd_wrapper.c",
@@ -50,6 +55,8 @@ cc_binary(
         "-DGZIP_SUPPORT",
         "-DLZ4_SUPPORT",
         "-DZSTD_SUPPORT",
+        "-DVERSION=\\\"4.5.1\\\"",  # from squashfs-tools/Makefile:2
+        "-DDATE=\\\"2022/03/17\\\"",  # from squashfs-tools/Makefile:3
     ],
     linkopts = [
         "-pthread",
@@ -67,6 +74,7 @@ cc_binary(
     srcs = [
         "squashfs-tools/compressor.c",
         "squashfs-tools/compressor.h",
+        "squashfs-tools/endian_compat.h",
         "squashfs-tools/error.h",
         "squashfs-tools/fnmatch_compat.h",
         "squashfs-tools/gzip_wrapper.c",
@@ -86,6 +94,7 @@ cc_binary(
         "squashfs-tools/unsquash-4.c",
         "squashfs-tools/unsquashfs.c",
         "squashfs-tools/unsquashfs.h",
+        "squashfs-tools/unsquashfs_error.h",
         "squashfs-tools/unsquashfs_info.c",
         "squashfs-tools/unsquashfs_info.h",
         "squashfs-tools/unsquashfs_xattr.c",
@@ -104,6 +113,8 @@ cc_binary(
         "-DGZIP_SUPPORT",
         "-DLZ4_SUPPORT",
         "-DZSTD_SUPPORT",
+        "-DVERSION=\\\"4.5.1\\\"",  # from squashfs-tools/Makefile:2
+        "-DDATE=\\\"2022/03/17\\\"",  # from squashfs-tools/Makefile:3
     ],
     linkopts = [
         "-pthread",


### PR DESCRIPTION
squashfs-tools 4.4 does not build with recent gcc. This is fixed in >=4.5. (See e.g. https://github.com/AppImage/AppImageKit/issues/1185)

4.5.1 (https://github.com/plougher/squashfs-tools/releases/tag/4.5.1) is the most recent release at time of writing.
All changes from 4.4 to 4.5.1: https://github.com/plougher/squashfs-tools/compare/4.4...4.5.1